### PR TITLE
Consistently name probe point provider and macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ $ sudo make install
 
 1. Compile the target crypto library with defined tracepoints are enabled
 ```console
-$ git clone --depth=1 -b wip/dueno/usdt https://gitlab.com/dueno/gnutls.git
+$ git clone --depth=1 -b wip/usdt https://gitlab.com/gnutls/gnutls.git
 $ ./bootstrap
 $ ./configure
 $ make -j$(nproc)
 ```
 2. Run the agent as root
 ```console
-$ sudo ./target/debug/crypto-auditing-agent --library .../gnutls/lib/.libs/libgnutls.so.30.34.2
+$ sudo ./target/debug/crypto-auditing-agent --library .../gnutls/lib/.libs/libgnutls.so.30.35.0
 ```
 3. On another terminal, run any commands using the instrumented library
 ```console

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ be installed with `gem install --user cbor-diag`.
 
 - `agent/src/bpf/audit.bpf.c`: GPL-2.0-or-later
 - `agent/src/ringbuf.rs`: LGPL-2.1-only or BSD-2-Clause
+- `dist/audit.h`: MIT
 - everything else: GPL-3.0-or-later
 
 ## Credits

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Ok(link) = prog.attach_usdt(
             -1, // any process
             library,
-            "audit",
+            "crypto_auditing",
             "new_context",
         ) {
             links.push(link);
@@ -90,7 +90,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Ok(link) = prog.attach_usdt(
             -1, // any process
             library,
-            "audit",
+            "crypto_auditing",
             "word_data",
         ) {
             links.push(link);
@@ -99,7 +99,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Ok(link) = prog.attach_usdt(
             -1, // any process
             library,
-            "audit",
+            "crypto_auditing",
             "string_data",
         ) {
             links.push(link);
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Ok(link) = prog.attach_usdt(
             -1, // any process
             library,
-            "audit",
+            "crypto_auditing",
             "blob_data",
         ) {
             links.push(link);

--- a/dist/audit.h
+++ b/dist/audit.h
@@ -3,41 +3,41 @@
 
 /* This file defines probe points used by crypto-auditing. */
 
-#ifdef ENABLE_AUDIT
+#ifdef ENABLE_CRYPTO_AUDITING
 
 # ifdef HAVE_SYS_SDT_H
 #  include <sys/sdt.h>
 # endif
 
 /* Introduce a new context CONTEXT, derived from PARENT */
-# define AUDIT_NEW_CONTEXT(context, parent)				\
-	DTRACE_PROBE2(audit, new_context, context, parent)
+# define CRYPTO_AUDITING_NEW_CONTEXT(context, parent)				\
+	DTRACE_PROBE2(crypto_auditing, new_context, context, parent)
 
 /* Assert an event with KEY and VALUE. The key is treated as a
  * NUL-terminated string, while the value is in the size of machine
  * word
  */
-# define AUDIT_WORD_DATA(context, key_ptr, value_ptr)			\
-	DTRACE_PROBE3(audit, word_data, context, key_ptr, value_ptr)
+# define CRYPTO_AUDITING_WORD_DATA(context, key_ptr, value_ptr)			\
+	DTRACE_PROBE3(crypto_auditing, word_data, context, key_ptr, value_ptr)
 
 /* Assert an event with KEY and VALUE. Both the key and value are
  * treated as a NUL-terminated string
  */
-# define AUDIT_STRING_DATA(context, key_ptr, value_ptr)			\
-	DTRACE_PROBE3(audit, string_data, context, key_ptr, value_ptr)
+# define CRYPTO_AUDITING_STRING_DATA(context, key_ptr, value_ptr)			\
+	DTRACE_PROBE3(crypto_auditing, string_data, context, key_ptr, value_ptr)
 
 /* Assert an event with KEY and VALUE. The key is treated as a
  * NUL-terminated string, while the value is explicitly sized with
  * VALUE_SIZE
  */
-# define AUDIT_BLOB_DATA(key_ptr, context, value_ptr, value_size)	\
-	DTRACE_PROBE4(audit, blob_data, context, key_ptr, value_ptr, value_size)
+# define CRYPTO_AUDITING_BLOB_DATA(key_ptr, context, value_ptr, value_size)	\
+	DTRACE_PROBE4(crypto_auditing, blob_data, context, key_ptr, value_ptr, value_size)
 
 #else
 
-# define AUDIT_NEW_CONTEXT(context, parent)
-# define AUDIT_WORD_DATA(context, key_ptr, value_ptr)
-# define AUDIT_STRING_DATA(context, key_ptr, value_ptr)
-# define AUDIT_BLOB_DATA(context, key_ptr, value_ptr, value_size)
+# define CRYPTO_AUDITING_NEW_CONTEXT(context, parent)
+# define CRYPTO_AUDITING_WORD_DATA(context, key_ptr, value_ptr)
+# define CRYPTO_AUDITING_STRING_DATA(context, key_ptr, value_ptr)
+# define CRYPTO_AUDITING_BLOB_DATA(context, key_ptr, value_ptr, value_size)
 
-#endif /* ENABLE_AUDIT */
+#endif /* ENABLE_CRYPTO_AUDITING */

--- a/docs/probe-points.md
+++ b/docs/probe-points.md
@@ -38,41 +38,41 @@ probes as follows:
 
 ```c
 /* Introduce a new context CONTEXT, derived from PARENT */
-# define AUDIT_NEW_CONTEXT(context, parent)				\
-	DTRACE_PROBE2(audit, new_context, context, parent)
+# define CRYPTO_AUDITING_NEW_CONTEXT(context, parent)				\
+	DTRACE_PROBE2(crypto_auditing, new_context, context, parent)
 
 /* Assert an event with KEY and VALUE. The key is treated as a
  * NUL-terminated string, while the value is in the size of machine
  * word
  */
-# define AUDIT_WORD_DATA(context, key_ptr, value_ptr)			\
-	DTRACE_PROBE3(audit, word_data, context, key_ptr, value_ptr)
+# define CRYPTO_AUDITING_WORD_DATA(context, key_ptr, value_ptr)			\
+	DTRACE_PROBE3(crypto_auditing, word_data, context, key_ptr, value_ptr)
 
 /* Assert an event with KEY and VALUE. Both the key and value are
  * treated as a NUL-terminated string
  */
-# define AUDIT_STRING_DATA(context, key_ptr, value_ptr)			\
-	DTRACE_PROBE3(audit, string_data, context, key_ptr, value_ptr)
+# define CRYPTO_AUDITING_STRING_DATA(context, key_ptr, value_ptr)			\
+	DTRACE_PROBE3(crypto_auditing, string_data, context, key_ptr, value_ptr)
 
 /* Assert an event with KEY and VALUE. The key is treated as a
  * NUL-terminated string, while the value is explicitly sized with
  * VALUE_SIZE
  */
-# define AUDIT_BLOB_DATA(key_ptr, context, value_ptr, value_size)	\
-	DTRACE_PROBE4(audit, blob_data, context, key_ptr, value_ptr, value_size)
+# define CRYPTO_AUDITING_BLOB_DATA(key_ptr, context, value_ptr, value_size)	\
+	DTRACE_PROBE4(crypto_auditing, blob_data, context, key_ptr, value_ptr, value_size)
 ```
 
 These macros can be invoked in the application logic:
 
 ```c
 /* Start TLS client handshake */
-AUDIT_NEW_CONTEXT(context, NULL);
+CRYPTO_AUDITING_NEW_CONTEXT(context, NULL);
 
 /* Indicate that this context is about TLS client handshake */
-AUDIT_STRING_DATA(context, "name", "tls::handshake_client");
+CRYPTO_AUDITING_STRING_DATA(context, "name", "tls::handshake_client");
 
 /* Indicate that TLS 1.3 is selected */
-AUDIT_WORD_DATA(context, "tls::protocol_version", 0x0304);
+CRYPTO_AUDITING_WORD_DATA(context, "tls::protocol_version", 0x0304);
 ```
 
 where `context` can be any object with the size of a machine word
@@ -105,8 +105,8 @@ overhead, we may consider using integer codepoints instead.
 #### Using implementation specific probe points
 
 Instead of using a key-value based event description, it is possible
-to define probe points that directly corresponds to certain
-implementation.  The following is an attempt along these lines,
+to define probe points that directly corresponds to particular
+implementation detail.  The following is an attempt along these lines,
 assuming internal algorithm identifiers used in GnuTLS:
 
 ```c


### PR DESCRIPTION
Previously the provider was named as "audit", which was a bit too
ambiguous when the target program also makes use of Linux audit.