### PR TITLE
Unpin libbpf from specific commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,8 +640,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.13.1"
-source = "git+https://github.com/libbpf/libbpf-rs.git?rev=7c9b754e396e89fc8a9129809f769d212f09e30f#7c9b754e396e89fc8a9129809f769d212f09e30f"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a63a7f053679c21efd43a50867ad5945c1cadaaea34e5c8182c4e3b2da199af"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -662,8 +663,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.19.1"
-source = "git+https://github.com/libbpf/libbpf-rs.git?rev=7c9b754e396e89fc8a9129809f769d212f09e30f#7c9b754e396e89fc8a9129809f769d212f09e30f"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c1401b366ec96859ef47e68a26f6b9e7cc2f241fafd8c844eba50033bf548b3"
 dependencies = [
  "bitflags",
  "lazy_static",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -12,8 +12,7 @@ bytes = "1.2"
 clap = { version = "4", features=["cargo", "derive"] }
 crypto-auditing-types = { path = "../types" }
 futures = "0.3"
-# The "novendor" feature currently requires libbpf-sys to be pulled in from the same repository
-libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs.git", rev = "7c9b754e396e89fc8a9129809f769d212f09e30f", features=["novendor"] }
+libbpf-rs = { version = "0.20", features=["novendor"] }
 libc = "0.2"
 nix = "0.24"
 openssl = "0.10"
@@ -26,5 +25,4 @@ tokio-uring = "0.4"
 toml = "0.6"
 
 [build-dependencies]
-# The "novendor" feature currently requires libbpf-sys to be pulled in from the same repository
-libbpf-cargo = { git = "https://github.com/libbpf/libbpf-rs.git", rev = "7c9b754e396e89fc8a9129809f769d212f09e30f", features=["novendor"] }
+libbpf-cargo = { version = "0.20", features=["novendor"] }


### PR DESCRIPTION
Unpin libbpf from specific commit now that there are releases with USDT probe support.