### PR TITLE
agent: Produce tracing output instead of error in loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,8 @@ dependencies = [
  "tokio",
  "tokio-uring",
  "toml 0.6.0",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -23,6 +23,8 @@ time = { version = "0.3", features=["formatting", "local-offset", "macros"] }
 tokio = { version = "1.23", features=["full"] }
 tokio-uring = "0.4"
 toml = "0.6"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features=["env-filter"] }
 
 [build-dependencies]
 libbpf-cargo = { version = "0.20", features=["novendor"] }

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -6,7 +6,7 @@ use clap::{arg, command, parser::ValueSource, value_parser, ArgAction, ArgMatche
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use tokio::time::{Duration, Instant};
+use tokio::time::Duration;
 use toml::{Table, Value};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -19,7 +19,7 @@ pub enum Format {
 const CONFIG: &'static str = "/etc/crypto-auditing/agent.conf";
 const LOG: &'static str = "/var/log/crypto-auditing/audit.cborseq";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Config {
     /// Path to library that defines probes
     pub library: Vec<PathBuf>,
@@ -145,18 +145,6 @@ impl Config {
         }
 
         Ok(config)
-    }
-
-    pub fn coalesce_window_elapsed(&self, instant: &Instant) -> bool {
-        self.coalesce_window
-            .map(|window| instant.elapsed() > window)
-            .unwrap_or(true)
-    }
-
-    pub fn should_rotate_after(&self, nevents: usize) -> bool {
-        self.max_events
-            .map(|max_events| nevents > max_events)
-            .unwrap_or(false)
     }
 
     fn merge_config_file(&mut self, file: impl AsRef<Path>) -> Result<()> {

--- a/agent/src/log_writer.rs
+++ b/agent/src/log_writer.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2022-2023 The crypto-auditing developers.
+
+use crate::config;
+use anyhow::{bail, Context as _, Result};
+use crypto_auditing::types::EventGroup;
+use serde_cbor::{ser::IoWrite, Serializer};
+use std::path::PathBuf;
+use time::{macros::format_description, OffsetDateTime};
+use tokio::time::{Duration, Instant};
+use tokio_uring::fs::{rename, File};
+
+pub struct LogWriter {
+    config: config::Config,
+    file: Option<File>,
+    offset: u64,
+    instant: Instant,
+    groups: Vec<EventGroup>,
+    written_events: usize,
+    pending_events: usize,
+}
+
+impl LogWriter {
+    pub async fn from_config(config: &config::Config) -> Result<Self> {
+        let file = File::create(&config.log_file)
+            .await
+            .with_context(|| format!("unable to create file `{}`", config.log_file.display()))?;
+        Ok(Self {
+            config: config.clone(),
+            file: Some(file),
+            offset: 0u64,
+            instant: Instant::now(),
+            groups: Vec::default(),
+            written_events: 0usize,
+            pending_events: 0usize,
+        })
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.instant.elapsed()
+    }
+
+    pub fn timeout(&self) -> Duration {
+        if self.groups.is_empty() {
+            // No previous event, wait indefinitely
+            Duration::MAX
+        } else if let Some(window) = self.config.coalesce_window {
+            // --coalesce-window is given, wait during the window
+            window
+                .checked_sub(self.instant.elapsed())
+                .unwrap_or(Duration::ZERO)
+        } else {
+            // Otherwise, wait indefinitely
+            Duration::MAX
+        }
+    }
+
+    pub fn coalesce_window_elapsed(&self) -> bool {
+        self.config
+            .coalesce_window
+            .map(|window| self.instant.elapsed() > window)
+            .unwrap_or(true)
+    }
+
+    fn should_rotate_after(&self, nevents: usize) -> bool {
+        self.config
+            .max_events
+            .map(|max_events| nevents > max_events)
+            .unwrap_or(false)
+    }
+
+    pub fn should_rotate(&self) -> bool {
+        self.should_rotate_after(self.written_events + self.pending_events)
+    }
+
+    pub fn push_group(&mut self, mut group: EventGroup) {
+        // Coalesce the event to the previous one, if possible
+        let coalesce_window_elapsed = self.coalesce_window_elapsed();
+        let should_rotate = self.should_rotate();
+        match self.groups.last_mut() {
+            Some(last)
+                if last.context() == group.context()
+                    && !coalesce_window_elapsed
+                    && !should_rotate =>
+            {
+                last.coalesce(&mut group)
+            }
+            _ => self.groups.push(group.clone()),
+        }
+        self.pending_events += 1;
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        let file = self.file.take().unwrap();
+
+        file.sync_all()
+            .await
+            .with_context(|| format!("unable to sync file `{}`", self.config.log_file.display()))?;
+
+        file.close().await.with_context(|| {
+            format!("unable to close file `{}`", self.config.log_file.display())
+        })?;
+
+        Ok(())
+    }
+
+    pub async fn rotate(&mut self) -> Result<()> {
+        self.close().await?;
+
+        let now = OffsetDateTime::now_local()?;
+
+        let mut backup_log_file = PathBuf::from(format!(
+            "{}-{}.0",
+            self.config.log_file.to_str().unwrap(),
+            now.format(&format_description!("[year]-[month]-[day]"))?,
+        ));
+        let mut counter = 0u64;
+        while backup_log_file.exists() {
+            counter += 1;
+            backup_log_file.set_extension(&counter.to_string());
+        }
+
+        rename(&self.config.log_file, &backup_log_file)
+            .await
+            .with_context(|| {
+                format!(
+                    "unable to rename file `{}` to `{}`",
+                    self.config.log_file.display(),
+                    backup_log_file.display(),
+                )
+            })?;
+
+        self.file = Some(File::create(&self.config.log_file).await.with_context(|| {
+            format!("unable to create file `{}`", self.config.log_file.display())
+        })?);
+
+        self.offset = 0;
+        self.written_events = 0;
+
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> Result<()> {
+        self.pending_events = 0;
+        for group in self.groups.clone() {
+            if self.should_rotate_after(self.written_events) {
+                self.rotate().await?;
+            }
+            let v = match self.config.format {
+                config::Format::Normal => serde_cbor::ser::to_vec(&group)?,
+                config::Format::Packed => serde_cbor::ser::to_vec_packed(&group)?,
+                config::Format::Minimal => to_vec_minimal(&group)?,
+            };
+            let (res, _) = match self.file {
+                Some(ref file) => file.write_at(v, self.offset).await,
+                _ => bail!("log file is not opened"),
+            };
+            let n = res?;
+            self.offset += n as u64;
+            self.written_events += group.events().len();
+        }
+        self.groups.clear();
+        self.instant = Instant::now();
+
+        Ok(())
+    }
+}
+
+fn to_vec_minimal<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: serde::Serialize,
+{
+    let mut vec = Vec::new();
+    value.serialize(
+        &mut Serializer::new(&mut IoWrite::new(&mut vec))
+            .packed_format()
+            .legacy_enums(),
+    )?;
+    Ok(vec)
+}


### PR DESCRIPTION
The previous code was returning from the loop when any error occurs.
This tolerates those errors but logs them in a tracing log.
