### PR TITLE
bpf: Emit error messages to DebugFS

### DIFF
--- a/agent/tests/coalesce.rs
+++ b/agent/tests/coalesce.rs
@@ -39,9 +39,13 @@ fn test_probe_coalesce() {
         .expect("unable to spawn agent");
 
     // Wait until the agent process starts up
-    while !log_path.exists() {
+    for _ in 0..5 {
+        if log_path.exists() {
+            break;
+        }
         thread::sleep(Duration::from_millis(100));
     }
+    assert!(log_path.exists());
 
     let result = panic::catch_unwind(|| {
         let foo = String::from("foo\0");

--- a/agent/tests/no_coalesce.rs
+++ b/agent/tests/no_coalesce.rs
@@ -37,9 +37,13 @@ fn test_probe_no_coalesce() {
         .expect("unable to spawn agent");
 
     // Wait until the agent starts up
-    while !log_path.exists() {
+    for _ in 0..5 {
+        if log_path.exists() {
+            break;
+        }
         thread::sleep(Duration::from_millis(100));
     }
+    assert!(log_path.exists());
 
     let result = panic::catch_unwind(|| {
         let foo = String::from("foo\0");


### PR DESCRIPTION
This makes the attached BPF program emit errors to DebugFS, as well as allows NULL data for `blob_data` event.