### PR TITLE
agent: Spawn event sender in a worker thread

### DIFF
--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -23,7 +23,7 @@ page_size.workspace = true
 serde.workspace = true
 serde_cbor.workspace = true
 time = { workspace = true, features = ["formatting", "local-offset", "macros"] }
-tokio = { workspace = true, features = ["fs", "io-util", "signal"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "signal"] }
 tokio-uring = { version = "0.4", optional = true }
 toml.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
The previous implementation used a synchronous channel within a single thread, resulting in the sender being blocked forever when the channel bound (256) has reached. This spawns a new worker thread for the sender so the receiver can read the event queue concurrently.