### PR TITLE
github: Silence dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,16 @@ updates:
     versioning-strategy: "lockfile-only"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      everything:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      everything:
+        patterns:
+          - "*"


### PR DESCRIPTION
This increases the interval from daily to weekly, as well as groups the PRs when possible.