### PR TITLE
agent: Drop unnecessary capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caps"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +338,7 @@ dependencies = [
  "agenttest",
  "anyhow",
  "bytes",
+ "caps",
  "clap",
  "crypto-auditing",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ authors = ["The crypto-auditing developers"]
 anyhow = "1.0"
 bindgen = "0.72"
 bytes = "1.2"
+caps = "0.5"
 clap = "4"
 crypto-auditing = { version = "=0.3.0", path = "crypto-auditing" }
 futures = "0.3"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -12,6 +12,7 @@ default = ["tokio-uring"]
 [dependencies]
 anyhow.workspace = true
 bytes.workspace = true
+caps.workspace = true
 clap = { workspace = true, features = ["cargo", "derive"] }
 crypto-auditing.workspace = true
 futures.workspace = true


### PR DESCRIPTION
To minimize the attack surface, this limits the Linux capabilities for the agent thread to CAP_BPF and CAP_PERFMON after the startup.