### PR TITLE
Fix CRAU_MAYBE_UNUSED definition for old compilers

### DIFF
--- a/dist/crau/crau.h
+++ b/dist/crau/crau.h
@@ -255,9 +255,15 @@ void crau_data(struct crau_context_stack_st *stack, ...)
 #    if __has_c_attribute (__maybe_unused__)
 #     define CRAU_MAYBE_UNUSED [[__maybe_unused__]]
 #    endif
-#   elif defined(__GNUC__)
+#   endif
+#  endif /* CRAU_MAYBE_UNUSED */
+#  ifndef CRAU_MAYBE_UNUSED
+#   ifdef __GNUC__
 #    define CRAU_MAYBE_UNUSED __attribute__((__unused__))
 #   endif
+#  endif /* CRAU_MAYBE_UNUSED */
+#  ifndef CRAU_MAYBE_UNUSED
+#   define CRAU_MAYBE_UNUSED
 #  endif /* CRAU_MAYBE_UNUSED */
 
 void crau_push_context(struct crau_context_stack_st *stack CRAU_MAYBE_UNUSED,


### PR DESCRIPTION
Fix behavior change that caused build failure with clang versions older than 17.

Also ensure CRAU_MAYBE_UNUSED is always defined to something, for even older compilers.

Patch ported from https://gitlab.com/gnutls/gnutls/-/merge_requests/2106