### PR TITLE
docs: Rework logging-format.md by splitting registry

### DIFF
--- a/docs/logging-format.md
+++ b/docs/logging-format.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This document specifies the format for a crypto-auditing primary event
+This document specifies the format for crypto-auditing primary event
 logs.
 
 To meet the practical use-cases, the proposed format is designed to be
@@ -14,41 +14,54 @@ establishment.
 
 ### Goals
 
-- Contextual format: the logging format should be able to represent
-  both high-level and low-level events, grouped by contexts
-- Log truncation tolerance: the log file can be truncated at arbitrary
-  record boundary
+- The format can convey contextual information. It can not only
+  represents individual cryptographic events (e.g., RSA signing), but
+  also provide the context (e.g., for which purpose it is used, such
+  as TLS).
+- The format can be represented in a compact form, such as CBOR packed
+  format to eliminating repetition.
+- The format provides basic tolerance of modification, e.g., the log
+  files can be truncated at any record boundary.
 
-### Non-goals
+### Overall structure
 
-- Human-readable format: there will be separate processes consuming
-  the log format and converting it to application-specific
-  representation
+Events are classified into two categories: data events and context
+events. Data events represent the events themselves as typed key-value
+pairs. Context events maintain the contexts associated with data
+events.
 
-### Logging format
+Contexts are identified by unique 16-byte values called context IDs,
+which are included in all types of events.
 
-The general structure of the logging format is a stream of structured
-event entries.
+Since the crypto-auditing agent monitor multiple processes, event
+sequences may be interleaved with each other. Context IDs enable
+reconstructing interleaved events into same context sequences.
 
-Events are classified into two categories: context mapping event and
-data event.  The former maintains contexts associated with the latter.
-The latter represents events themselves in a form of key-value pairs.
-
-#### Example: TLS client handshake
+### Example: TLS client handshake
 
 A TLS handshake consists of several cryptographic operations, such as
-digital-signature verification and key derivation.  For simplicity,
-let's assume only digital-signature operations are involved.
+digital signature verification and key derivation. For simplicity,
+let's assume only digital signature operations are involved.
 
-There will be two contexts: an entire TLS handshake, and
-digital-signature verification or creation, each of them is associated
-to data events which describe the detail of those events, e.g., TLS
-protocol version and digital-signature algorithm used.
+There will be two contexts: one for the entire TLS handshake, and
+another for digital signature verification or creation. Each context is
+associated with data events that describe the details of those events,
+e.g., TLS protocol version and digital signature algorithm used.
 
-Contexts are identified by unique 16-byte values, which are included
-in any kind of events.  If the events were represented as a JSON
-array, the log file would conceptually look like the following, though
-a more efficient (binary) format will be used in practical deployment.
+Therefore, at a high level, a TLS client handshake is represented as
+a tree as follows:
+
+- `tls::handshake` (00..01)
+  - `tls::role` = "client"
+  - `tls::protocol_version` = 0x0304
+  - `tls::verify` (00..02)
+    - `tls::signature_algorithm` = 0x0804
+    - `pk::bits` = 3072
+
+At a low level, this is represented as a stream of structured event
+entries.  If the log file is represented as a JSON array, it would
+conceptually look like the following, though a more efficient (binary)
+format is used in practice.
 
 ```json
 [
@@ -60,7 +73,12 @@ a more efficient (binary) format will be used in practical deployment.
     {
         "type": "string_data",
         "context": "00..01",
-        "name": "tls::handshake_client"
+        "name": "tls::handshake"
+    },
+    {
+        "type": "string_data",
+        "context": "00..01",
+        "tls::role": "client"
     },
     {
         "type": "word_data",
@@ -90,46 +108,73 @@ a more efficient (binary) format will be used in practical deployment.
 ]
 ```
 
-This can be conceptually represented as a tree of events:
+### Guidance on defining events
 
-- `tls::handshake_client` (00..01)
-  - `tls::protocol_version` = 0x0304
-  - `tls::verify` (00..02)
-    - `tls::signature_algorithm` = 0x0804
-    - `pk::bits` = 3072
+This section provides some guidance on designing and organizing the
+events for a new protocol.
 
-Since the agent can monitor multiple processes, event sequences could
-be interleaved with each other.  In that situation, context IDs help
-to recover the original event sequences.
+#### Naming of event keys
+
+Event keys are named with alphanumeric characters and underscores,
+with an optional scope prefix delimited by "::". More formally, they
+are written in ABNF as follows:
+
+```text
+nchars = ALPHA *(ALPHA / DIGIT / "_")
+
+key = [nchars "::"] nchars
+```
+
+Scopes are used to denote a protocol namespace, such as TLS.
+
+#### Types of event values
+
+A data event conveys a data item that is either a NUL-terminated string,
+an integer that fits in a machine word, or an arbitrary blob with a
+specified length.
+
+For example, `name` takes a string value, while
+`tls::protocol_version` takes an integer that corresponds to the
+[`ProtocolVersion`][protocol-version] value in TLS.
+
+For values that don't have an integral value assigned by the protocol
+standards, it's recommended to use a string value instead of coming up
+with synthetic integer ones.
+
+While it is possible to represent a boolean value by choosing whether
+or not to emit a data event, it is recommended to explicitly emit an
+integer data event with value 0 or 1. This allows the application to
+determine the value immediately, even when event sequence compression
+(see below) is enabled.
 
 #### Context ID construction
 
-For security and privacy reasons, context ID should be constructed to
-be indistinguishable from the internal state of target programs, e.g.,
-PID or memory address, while those information could be used as an
-input to the construction algorithm. The recommended way of
-constructing context ID as follows:
+For security and privacy reasons, context IDs should be constructed to
+not reveal internal state of target programs, such as PIDs or memory
+addresses, although such information may be used as input to the
+construction algorithm. The recommended way to construct a context ID
+is as follows:
 
-- The agent initializes an encryption key used with AES-ECB at startup
+- The agent initializes an encryption key for AES-ECB at startup
 - An 8-byte context ID and an 8-byte PID/TGID of the target program
-  are concatenated to construct a 16-byte input (i.e., a single block
-  of AES-ECB)
-- Encrypt the 16-byte input with AES-ECB using the key created above
+  are concatenated to construct a 16-byte input (i.e., a single AES-ECB
+  block)
+- The 16-byte input is encrypted with AES-ECB using the key created above
 
-This is inspired by the similar mechanism to [record number
-encryption][rn-enc] in QUIC and DTLS 1.3 protocols.  With the AES-NI
-instruction set enabled, this procedure consumes up to 15 cycles.
+This is inspired by a similar mechanism for [record number
+encryption][rn-enc] in the QUIC and DTLS 1.3 protocols. With the AES-NI
+instruction set enabled, this procedure takes up to 15 cycles.
 
 The agent may periodically rotate the key.
 
 #### Event sequence compression based on context
 
 When multiple events are sent within a single context, the same
-context IDs are written into the log file, which could unnecessarily
+context IDs are written to the log file, which can unnecessarily
 consume disk space. Therefore, the log format supports compression of
-subsequent events that share the same context ID, given a certain time
-window.  With the compression enabled, the above example would look
-like the following, preserving the same semantics:
+consecutive events that share the same context ID within a given time
+window. With compression enabled, the above example would look like the
+following while preserving the same semantics:
 
 ```json
 [
@@ -142,7 +187,11 @@ like the following, preserving the same semantics:
             },
             {
                 "type": "string_data",
-                "name": "tls::handshake_client"
+                "name": "tls::handshake"
+            },
+            {
+                "type": "string_data",
+                "tls::role": "client"
             },
             {
                 "type": "word_data",
@@ -174,160 +223,10 @@ like the following, preserving the same semantics:
 ]
 ```
 
-### Naming of event keys
+### Mapping to CBOR
 
-While the keys can be arbitrary, this section provides a guidance on
-how to construct them.  There are two types of keys: generic keys and
-scoped keys.  Generic keys consists of only alphanumeric characters
-and an underscore, while scoped keys can have a prefix ending with
-"::".  In the previous example, `name` is a generic key, while
-`tls::protocol_version` is a scoped key.  More strictly, they are
-written in ABNF as follows:
-
-```text
-name = ALPHA *(ALPHA / DIGIT / "_")
-
-generic_key = name
-scoped_key = name "::" name
-```
-
-Keys are also used to determine value types.  For example, `name` can
-take a string value, while `tls::protocol_version` takes a 16-bit
-integer that corresponds to [`ProtocolVersion`][protocol-version]
-(i.e., a 16-bit integer) in TLS.
-
-The registry of those key names should be maintained in a separate
-document.  The following section defines a few generic probe points
-and TLS probe points.
-
-#### Event keys registry
-
-##### Generic keys
-
-| key    | value type | description                                                     |
-|--------|------------|-----------------------------------------------------------------|
-| `name` | string     | the name of current context (available names are defined below) |
-
-##### TLS context names
-
-| name                    | description                                                      |
-|-------------------------|------------------------------------------------------------------|
-| `tls::handshake_client` | TLS handshake for client                                         |
-| `tls::handshake_server` | TLS handshake for server                                         |
-| `tls::sign`             | Digital signature is created using certificate in TLS handshake  |
-| `tls::verify`           | Digital signature is verified using certificate in TLS handshake |
-| `tls::key_exchange`     | Shared secret derivation in TLS handshake                        |
-
-##### TLS keys
-
-| key                                | value type     | description                                                                                      |
-|------------------------------------|----------------|--------------------------------------------------------------------------------------------------|
-| `tls::protocol_version`            | uint16         | Negotiated TLS version                                                                           |
-| `tls::ciphersuite`                 | uint16         | Negotiated ciphersuite (as in IANA [registry][iana-tls-ciphersuites])                            |
-| `tls::signature_algorithm`         | uint16         | Signature algorithm used in the handshake (as in IANA [registry][iana-tls-signature-algorithms]) |
-| `tls::key_exchange_algorithm`      | uint16         | Key exchange mode: ECDHE(0), DHE(1), PSK(2), ECDHE-PSK(3), DHE-PSK(4)                            |
-| `tls::group`                       | uint16         | Groups used in the handshake (as in IANA [registry][iana-tls-supported-groups])                  |
-| `tls::ext::extended_master_secret` | word (ignored) | Present when extended_master_secret extension is negotiated                                      |
-
-##### SSH context names
-
-| name                   | description                            |
-|------------------------|----------------------------------------|
-| `ssh::handshake_client`| SSH handshake for client               |
-| `ssh::handshake_server`| SSH handshake for server               |
-| `ssh::client_key`      | SSH client key signature/verification  |
-| `ssh::server_key`      | SSH server key signature/verification  |
-| `ssh::key_exchange`    | SSH key exchange                       |
-
-##### SSH keys
-
-All the keys except `rsa_bits` have `string` type.
-We distinguish server and client values by the context we are in. We log all relevant events in both contexts.
-
-| key                             | description                                      | example                    |
-|---------------------------------|--------------------------------------------------|----------------------------|
-| `ssh::ident_string`             | Software identification string                   | `SSH-2.0-OpenSSH_8.8`      |
-| `ssh::peer_ident_string`        | Peer software identification string              | `SSH-2.0-OpenSSH_8.8`      |
-| `ssh::key_algorithm`            | Key used in handshake/key ownership proof        | `ssh-ed25519`              |
-| `ssh::rsa_bits`                 | Key bits (RSA only)                              | 2048                       |
-| `ssh::cert_signature_algorithm` | If cert is used, signature algorithm of the cert | `ecdsa-sha2-nistp521`      |
-| `ssh::kex_algorithm`            | Negotiated key exchange algorithm                | `curve25519-sha256`        |
-| `ssh::kex_group`                | Group used for key exchange                      | moduli+bits or group name. |
-| `ssh::c2s_cipher`               | Data cipher algorithm                            | `aes256-gcm@openssh.com`   |
-| `ssh::s2c_cipher`               |                                                  |                            |
-| `ssh::c2s_mac`                  | Data integrity algorithm, omitted for `implicit` | `umac-128-etm@openssh.com` |
-| `ssh::s2c_mac`                  |                                                  |                            |
-| `ssh::c2s_compression`          | Data compression algorithm, omitted for `none`   | `zlib@openssh.com`         |
-| `ssh::s2c_compression`          |                                                  |                            |
-
-##### Example of SSH context tree:
-
-- `ssh::handshake_client`
-  - `ssh::ident_string` = `SSH-2.0-OpenSSH_8.8`
-  - `ssh::peer_ident_string` = `SSH-2.0-OpenSSH_8.8`
-  - `ssh::key_exchange`
-    - `ssh::kex_algorithm` = `curve25519-sha256`
-    - `ssh::key_algorithm` = `ssh-ed25519`
-    - `ssh::s2c_cipher` = `aes256-gcm@openssh.com`
-    - `ssh::c2s_cipher` = `aes256-gcm@openssh.com`
-  - `ssh::server_key`
-    - `ssh::key_algorithm` = `ssh-ed25519`
-  - `ssh::client_key`
-    - `ssh::key_algorithm` = `ssh-ed25519`
-  - `ssh::server_key`
-    - `ssh::key_algorithm` = `rsa-sha2-256`
-    - `ssh::rsa_bits` = 2048
-  - `ssh::server_key`
-    - `ssh::key_algorithm` = `ecdsa-sha2-nistp256`
-
-##### Generic public key cryptography context names
-
-These contexts are only useful when a public key operation cannot be
-determined from the outer context. If it is obvious from the outer
-context, the probe point provider may choose to not create a new
-context.  For example, when the parent context is
-`tls::verify`, there is no need to create a new context
-with `pk::verify`.
-
-| name              | description                     |
-|-------------------|---------------------------------|
-| `pk::sign`        | A digital signature is created  |
-| `pk::verify`      | A digital signature is verified |
-| `pk::encrypt`     | Encryption is performed         |
-| `pk::decrypt`     | Decryption is performed         |
-| `pk::encapsulate` | A session key is encapsulated   |
-| `pk::decapsulate` | A session key is decpasulated   |
-| `pk::generate`    | A private key is generated      |
-| `pk::derive`      | A shared secret is generated    |
-
-##### Generic public key cryptography keys
-
-The event keys defined here can be attached to any context, not
-limited to the `pk` contexts defined above.
-
-These event keys are only useful when public key algorithm parameters
-cannot be determined from the outer context. If all the parameters are
-obvious from the outer context, the probe point provider may choose to
-not emit the `pk` events.  For example, when the parent context has
-`tls::signature_algorithm`, there is no need to emit `pk::algorithm`.
-
-All the keys except `pk::static` have `string` type. The values can be
-arbitrary and it is a responsibility of the data consumers to
-correlate them.
-
-| key             | value type     | description                                                                                                                |
-|-----------------|----------------|----------------------------------------------------------------------------------------------------------------------------|
-| `pk::algorithm` | string         | Used algorithm name                                                                                                        |
-| `pk::curve`     | string         | Elliptic curve name                                                                                                        |
-| `pk::group`     | string         | FFDH group name                                                                                                            |
-| `pk::bits`      | uint16         | Key strength in bits                                                                                                       |
-| `pk::hash`      | string         | Hash algorithm used for signing or encryption (for prehashed or parametrized schemes such as ECDSA, RSA-PSS, and RSA-OAEP) |
-| `pk::static`    | word (ignored) | Present when `pk::derive` takes place with reused keys                                                                     |
-
-### CBOR based logging format definition
-
-The recommended format of storing events is to use a sequence of
-[CBOR] (Concise Binary Object Representation) objects.  The following
+The recommended format for storing events is a sequence of
+[CBOR] (Concise Binary Object Representation) objects. The following
 is the formal definition in [CDDL] (Concise Data Definition Language):
 
 ```text
@@ -358,13 +257,13 @@ Data = {
 }
 ```
 
-The log consists of a series of `EventGroup` objects, which groups
-events in given time window from `start` to `end`.  Timestamps are
-represented as a monotonic duration from the kernel boot time.
-`ContextId` is an encrypted 16-byte context.
+The log consists of a series of `EventGroup` objects, each grouping
+events within a given time window from `start` to `end`. Timestamps are
+represented as monotonic durations from kernel boot time.
+`ContextId` is an encrypted 16-byte context identifier.
 
-The first `EventGroup` may be a virtual metadata group, whose
-`ContextId` is all-zero. This is used for including environmental
+The first `EventGroup` may be a virtual metadata group with an
+all-zero `ContextId`. This is used to include environmental
 information as event entries. The following events are currently
 defined:
 
@@ -373,26 +272,7 @@ defined:
 | `version`   | word       | the file format version (should be 1)       |
 | `boot_time` | word       | kernel boot time in seconds from Unix epoch |
 
-### Drawbacks and alternatives
-
-### Questions
-
-* How are algorithm identifiers represented in the log format and the
-  protocol? String representation would require memory allocation at
-  the BPF level, which might not be ideal. Integer representation
-  would impose translation to the consumer components in the later
-  pipeline. In both cases we need a registry to standardize known
-  algorithm identifiers.
-
-### Prior art
-
-- Distributed tracing in microservices is a pattern that makes it easy to track end-to-end requests, by associating contexts to durations ("spans") of each service processing the requests ([explainer blog article](https://signoz.io/blog/distributed-tracing/), [another blog article](https://www.datadoghq.com/knowledge-center/distributed-tracing/))
-- [KEP-3077: contextual logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging) is a proposal to add contextual logging to Kubernetes, by allowing the context to be swapped
-- [The SSLKEYLOGFILE Format](https://www.ietf.org/archive/id/draft-thomson-tls-keylogfile-00.html#section-3) which uses 32 byte value of the Random field from the ClientHello message to distinguish TLS connections
-
 [CBOR]: https://www.rfc-editor.org/rfc/rfc7049
 [CDDL]: https://www.rfc-editor.org/rfc/rfc8610
-[iana-tls-ciphersuites]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4
-[iana-tls-signature-algorithms]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16
-[iana-tls-supported-groups]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+[protocol-version]: https://www.rfc-editor.org/info/rfc8446/#appendix-D.1
 [rn-enc]: https://www.rfc-editor.org/rfc/rfc9147.html#name-record-number-encryption

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,284 @@
+# Event keys registry
+
+This document defines the registry of event key names used throughout
+the crypto-auditing system. The following sections define generic probe
+points as well as protocol-specific probe points for TLS and SSH.
+
+## Presentation language
+
+A protocol is typically defined with a context hierarchy, which can be
+defined using the following presentation syntax.
+
+### Miscellaneous
+
+Comments begin with `"/*"` and end with `"*/"`.
+
+### Scope
+
+A scope groups multiple related events within a namespace. It is
+defined using `scope <name> { ... }`, where `<name>` is the scope name.
+The body of this block may contain context events or data events.
+
+### Data events
+
+A data event is defined using `<name>: <type>;`, where `<name>` is the
+name of the data event and `<type>` is its data type. For example:
+
+```
+s1: string;
+```
+
+Available types are defined as follows:
+
+| type   | representation | description                       |
+|--------|----------------|-----------------------------------|
+| string | string         | a NUL-terminated string           |
+| blob   | blob           | a binary blob                     |
+| bool   | word           | boolean (0 for false, 1 for true) |
+| uint8  | word           | 8-bit unsigned integer            |
+| uint16 | word           | 16-bit unsigned integer           |
+| uint32 | word           | 32-bit unsigned integer           |
+| uint64 | word           | 64-bit unsigned integer           |
+| int8   | word           | 8-bit signed integer              |
+| int16  | word           | 16-bit signed integer             |
+| int32  | word           | 32-bit signed integer             |
+| int64  | word           | 64-bit signed integer             |
+
+### Context events
+
+A context event is defined using a `context <name> { ... }` block,
+where `<name>` is the name of the context event. The body of this block
+may contain data events or other context events.
+
+For example, 
+
+```
+context c1 {
+  s1: string;
+  context c2 {
+    u1: uint16;
+	context c3 {
+	  i1: int16;
+	}
+  }
+}
+```
+
+The hierarchy of context events must be preserved within the same scope.
+In the example above, `c2` cannot appear at the top level, and `c3`
+cannot be placed directly under `c1`.
+
+However, context events from different scopes can be nested together.
+For example, `pk::derive` (defined below) may appear within
+`tls::key_exchange`.
+
+## Generic data events
+
+The following are generic data events that can be associated with any
+context:
+
+| key    | value type | description                                                     |
+|--------|------------|-----------------------------------------------------------------|
+| `name` | string     | the name of the current context (available names are defined below) |
+
+## Public key cryptography
+
+Events for generic public key cryptography are scoped with `pk` and
+defined as follows:
+
+```
+scope pk {
+  context sign {
+    algorithm: string;
+	curve: string;
+	bits: uint16;
+	hash: string;
+  }
+
+  context verify {
+    algorithm: string;
+	curve: string;
+	bits: uint16;
+	hash: string;
+  }
+
+  context encrypt {
+    algorithm: string;
+	bits: uint16;
+	hash: string;
+  }
+
+  context decrypt {
+    algorithm: string;
+	bits: uint16;
+	hash: string;
+  }
+
+  context encapsulate {
+    algorithm: string;
+  }
+
+  context decapsulate {
+    algorithm: string;
+  }
+
+  context generate {
+    algorithm: string;
+	bits: uint16;
+  }
+
+  context derive {
+    algorithm: string;
+	curve: string;
+	bits: uint16;
+	static: bool;
+  }
+}
+```
+
+### Public key cryptography context events
+
+| name              | description                     |
+|-------------------|---------------------------------|
+| `pk::sign`        | A digital signature is created  |
+| `pk::verify`      | A digital signature is verified |
+| `pk::encrypt`     | Encryption is performed         |
+| `pk::decrypt`     | Decryption is performed         |
+| `pk::encapsulate` | A session key is encapsulated   |
+| `pk::decapsulate` | A session key is decapsulated   |
+| `pk::generate`    | A private key is generated      |
+| `pk::derive`      | A shared secret is generated    |
+
+### Public key cryptography data events
+
+| key             | value type | description                                                                                                                |
+|-----------------|------------|----------------------------------------------------------------------------------------------------------------------------|
+| `pk::algorithm` | string     | Used algorithm name                                                                                                        |
+| `pk::curve`     | string     | Elliptic curve name                                                                                                        |
+| `pk::group`     | string     | FFDH group name                                                                                                            |
+| `pk::bits`      | uint16     | Key strength in bits                                                                                                       |
+| `pk::hash`      | string     | Hash algorithm used for signing or encryption (for prehashed or parametrized schemes such as ECDSA, RSA-PSS, and RSA-OAEP) |
+| `pk::static`    | bool       | Whether `pk::derive` takes place with reused keys                                                                          |
+
+## TLS
+
+Events for TLS (Transport Layer Security) are scoped with `tls` and
+defined as follows:
+
+```
+scope tls {
+  context handshake {
+    role: string;
+	protocol_version: uint16;
+	ciphersuite: uint16;
+
+	context sign {
+	  signature_algorithm: uint16;
+	}
+
+	context verify {
+	  signature_algorithm: uint16;
+	}
+
+	context key_exchange {
+	  group: uint16;
+	}
+
+	extended_master_secret: bool;
+  }
+}
+```
+
+### TLS context events
+
+| name                | description                                                      |
+|---------------------|------------------------------------------------------------------|
+| `tls::handshake`    | TLS handshake                                                    |
+| `tls::sign`         | Digital signature is created using certificate in TLS handshake  |
+| `tls::verify`       | Digital signature is verified using certificate in TLS handshake |
+| `tls::key_exchange` | Shared secret derivation in TLS handshake                        |
+
+### TLS data events
+
+| name                          | type   | description                                                                                      |
+|-------------------------------|--------|--------------------------------------------------------------------------------------------------|
+| `tls::role`                   | string | The role of a peer ("client" or "server")                                                        |
+| `tls::protocol_version`       | uint16 | Negotiated TLS version                                                                           |
+| `tls::ciphersuite`            | uint16 | Negotiated ciphersuite (as in IANA [registry][iana-tls-ciphersuites])                            |
+| `tls::signature_algorithm`    | uint16 | Signature algorithm used in the handshake (as in IANA [registry][iana-tls-signature-algorithms]) |
+| `tls::group`                  | uint16 | Groups used in the handshake (as in IANA [registry][iana-tls-supported-groups])                  |
+| `tls::extended_master_secret` | bool   | Whether extended_master_secret extension is negotiated                                           |
+
+## SSH
+
+Events for SSH (Secure SHell) are scoped with `ssh` and defined as
+follows:
+
+```
+scope ssh {
+  context handshake {
+    role: string;
+	ident_string: string;
+	peer_ident_string: string;
+	context key_exchange {
+	  kex_algorithm: string;
+	  kex_group: string;
+	  key_algorithm: string;
+	  c2s_cipher: string;
+	  s2c_cipher: string;
+	  c2s_mac: string;
+	  s2c_mac: string;
+	  c2s_compression: string;
+	  s2c_compression: string;
+	}
+
+	context client_key {
+	  key_algorithm: string;
+	  cert_signature_algorithm: string;
+	  rsa_bits: uint16;
+	}
+
+	context server_key {
+	  key_algorithm: string;
+	  cert_signature_algorithm: string;
+	  rsa_bits: uint16;
+	}
+  }
+}
+```
+
+### SSH context events
+
+| name                    | description                           |
+|-------------------------|---------------------------------------|
+| `ssh::handshake`        | SSH handshake                         |
+| `ssh::client_key`       | SSH client key signature/verification |
+| `ssh::server_key`       | SSH server key signature/verification |
+| `ssh::key_exchange`     | SSH key exchange                      |
+
+### SSH data events
+
+All keys except `rsa_bits` have `string` type.
+Server and client values are distinguished by their context. All relevant events are logged in both contexts.
+
+| name                            | type   | description                                                                     |
+|---------------------------------|--------|---------------------------------------------------------------------------------|
+| `ssh::role`                     | string | The role of a peer ("client" or "server")                                       |
+| `ssh::ident_string`             | string | Software identification string, such as `SSH-2.0-OpenSSH_8.8`                   |
+| `ssh::peer_ident_string`        | string | Peer software identification string, such as `SSH-2.0-OpenSSH_8.8`              |
+| `ssh::key_algorithm`            | string | Key used in handshake/key ownership proof, such as `ssh-ed25519`                |
+| `ssh::rsa_bits`                 | uint16 | Key bits (RSA only)                                                             |
+| `ssh::cert_signature_algorithm` | string | If cert is used, signature algorithm of the cert, such as `ecdsa-sha2-nistp521` |
+| `ssh::kex_algorithm`            | string | Negotiated key exchange algorithm, such as `curve25519-sha256`                  |
+| `ssh::kex_group`                | string | Group used for key exchange                                                     |
+| `ssh::c2s_cipher`               | string | Data cipher algorithm, such as `aes256-gcm@openssh.com`                         |
+| `ssh::s2c_cipher`               | string | Data cipher algorithm, such as `aes256-gcm@openssh.com`                         |
+| `ssh::c2s_mac`                  | string | Data integrity algorithm, such as `umac-128-etm@openssh.com`                    |
+| `ssh::s2c_mac`                  | string | Data integrity algorithm, such as `umac-128-etm@openssh.com`                    |
+| `ssh::c2s_compression`          | string | Data compression algorithm, such as `zlib@openssh.com`                          |
+| `ssh::s2c_compression`          | string | Data compression algorithm, such as `zlib@openssh.com`                          |
+
+[iana-tls-ciphersuites]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4
+[iana-tls-signature-algorithms]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16
+[iana-tls-supported-groups]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+[rn-enc]: https://www.rfc-editor.org/rfc/rfc9147.html#name-record-number-encryption


### PR DESCRIPTION
This also does:

- merge tls::handshake_{client,server} and add tls::role
- merge ssh::handshake_{client,server} and add ssh::role
- remove tls::key_exchange_algorithm
- rename tls::ext::extended_master_secret
- define presentation language for defining protocols