### PR TITLE
types: Allow context reuse in ContextTracker

### DIFF
--- a/crypto-auditing/src/types.rs
+++ b/crypto-auditing/src/types.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2022-2023 The crypto-auditing developers.
 
-use serde::{
-    Deserialize, Serialize,
-    ser::{SerializeSeq, Serializer},
-};
+use serde::{Deserialize, Serialize, ser::Serializer};
 use serde_with::{hex::Hex, serde_as};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -19,18 +16,6 @@ pub type ContextId = [u8; 16];
 
 /// Context ID associated with `EventGroup` representing metadata
 pub const METADATA_CONTEXT_ID: ContextId = [0; 16];
-
-fn only_values<K, V, S>(source: &BTreeMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    V: Serialize,
-{
-    let mut seq = serializer.serialize_seq(Some(source.len()))?;
-    for value in source.values() {
-        seq.serialize_element(value)?;
-    }
-    seq.end()
-}
 
 fn to_string_lossy<S>(source: &CString, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -54,14 +39,13 @@ pub struct Context {
     #[serde_as(as = "serde_with::TimestampSecondsWithFrac<f64>")]
     pub end: SystemTime,
     pub events: BTreeMap<String, EventData>,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    #[serde(serialize_with = "only_values")]
-    pub spans: BTreeMap<ContextId, Rc<RefCell<Context>>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub spans: Vec<Rc<RefCell<Context>>>,
 }
 
 #[derive(Debug)]
 pub struct ContextTracker {
-    all_contexts: BTreeMap<ContextId, Rc<RefCell<Context>>>,
+    all_contexts: Vec<Rc<RefCell<Context>>>,
     root_contexts: Vec<Rc<RefCell<Context>>>,
     boot_time: SystemTime,
 }
@@ -69,7 +53,7 @@ pub struct ContextTracker {
 impl ContextTracker {
     pub fn new(boot_time: Option<SystemTime>) -> Self {
         Self {
-            all_contexts: BTreeMap::new(),
+            all_contexts: Vec::new(),
             root_contexts: Vec::new(),
             boot_time: boot_time.unwrap_or_else(|| {
                 UNIX_EPOCH
@@ -81,17 +65,16 @@ impl ContextTracker {
 
     pub fn flush(&mut self, before: Option<SystemTime>) -> impl IntoIterator<Item = Context> {
         let mut removed = Vec::new();
+        let expired = |context: &Rc<RefCell<Context>>| matches!(before, Some(before) if context.borrow().start > before);
         self.root_contexts.retain(|context| {
-            if let Some(before) = before
-                && context.borrow().start > before
-            {
+            if expired(context) {
                 true
             } else {
-                self.all_contexts.remove(&context.borrow().id[..]);
                 removed.push(context.clone());
                 false
             }
         });
+        self.all_contexts.retain(|context| expired(context));
         removed
             .into_iter()
             .map(|context| Rc::into_inner(context).unwrap().into_inner())
@@ -123,19 +106,31 @@ impl ContextTracker {
                         events: Default::default(),
                         spans: Default::default(),
                     }));
-                    if let Some(parent) = self.all_contexts.get(&parent_context[..]) {
-                        parent
-                            .borrow_mut()
-                            .spans
-                            .insert(*group.context(), context.clone());
+                    if let Some(parent) = self
+                        .all_contexts
+                        .iter()
+                        .rev()
+                        .find(|x| x.borrow().id == parent_context[..])
+                    {
+                        parent.borrow_mut().spans.push(context.clone());
                     } else {
                         self.root_contexts.push(context.clone());
                         count += 1;
                     }
-                    self.all_contexts.insert(*group.context(), context);
+                    self.all_contexts.push(context);
                 }
                 Event::Data { key, value } => {
-                    if !self.all_contexts.contains_key(group.context()) {
+                    if let Some(parent) = self
+                        .all_contexts
+                        .iter()
+                        .rev()
+                        .find(|x| x.borrow().id == *group.context())
+                    {
+                        parent
+                            .borrow_mut()
+                            .events
+                            .insert(key.to_string(), value.clone());
+                    } else {
                         // Either this library did not do a new_context for this context, or the
                         // log we have is truncated at the beginning. Just assume that this context
                         // has no parent and create a new one so we don't lose the information in
@@ -150,14 +145,8 @@ impl ContextTracker {
                             spans: Default::default(),
                         }));
                         self.root_contexts.push(context_obj.clone());
-                        self.all_contexts.insert(*group.context(), context_obj);
+                        self.all_contexts.push(context_obj);
                         count += 1;
-                    }
-                    if let Some(parent) = self.all_contexts.get(group.context()) {
-                        parent
-                            .borrow_mut()
-                            .events
-                            .insert(key.to_string(), value.clone());
                     }
                 }
             }

--- a/fixtures/logs/since-until/none.json
+++ b/fixtures/logs/since-until/none.json
@@ -14,6 +14,41 @@
         "context": "3cb4522554c9b0dc609cb15a60e8066d",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
+        "start": 1771974803.010911,
+        "end": 1771974803.010911,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "f34bb5200436326560d85aa040c2edc4",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974803.010913,
+            "end": 1771974803.010913,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "4886da6e495c21dd4269881115794cc2",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974803.0110207,
+            "end": 1771974803.0110207,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ECDH (X25519)"
+            }
+          }
+        ]
+      },
+      {
+        "context": "3cb4522554c9b0dc609cb15a60e8066d",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
         "start": 1771974803.0110753,
         "end": 1771974803.0110753,
         "events": {
@@ -71,18 +106,6 @@
         ]
       },
       {
-        "context": "ba2f7865e4de038b3da670176ac134aa",
-        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-        "executable": "",
-        "start": 1771974803.0425448,
-        "end": 1771974803.0425448,
-        "events": {
-          "name": "pk::verify",
-          "pk::algorithm": "RSA",
-          "pk::bits": 2048
-        }
-      },
-      {
         "context": "dcb5668c7981c908da00c4f485aa28fe",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
@@ -107,6 +130,30 @@
             }
           }
         ]
+      },
+      {
+        "context": "ba2f7865e4de038b3da670176ac134aa",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974803.0423572,
+        "end": 1771974803.0423572,
+        "events": {
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 4096
+        }
+      },
+      {
+        "context": "ba2f7865e4de038b3da670176ac134aa",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974803.0425448,
+        "end": 1771974803.0425448,
+        "events": {
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 2048
+        }
       }
     ]
   },
@@ -121,6 +168,41 @@
       "tls::protocol_version": 772
     },
     "spans": [
+      {
+        "context": "4496299804038c7e426b63ba21e82767",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974863.2147295,
+        "end": 1771974863.2147295,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "1f7c9636c1a8b39cc33164443e937a9a",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2147315,
+            "end": 1771974863.2147315,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "ba9a72d4606fc745e6a46281e9e0d88c",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2148237,
+            "end": 1771974863.2148237,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ECDH (X25519)"
+            }
+          }
+        ]
+      },
       {
         "context": "4496299804038c7e426b63ba21e82767",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
@@ -142,6 +224,41 @@
               "name": "pk::generate",
               "pk::algorithm": "EC/ECDSA",
               "pk::curve": "SECP256R1"
+            }
+          }
+        ]
+      },
+      {
+        "context": "9c3eb879769d1ca094404184669f6d60",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974863.2288046,
+        "end": 1771974863.2288046,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "6b12b88a73508c86569afb171fc86fa2",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2288072,
+            "end": 1771974863.2288072,
+            "events": {
+              "name": "pk::decapsulate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "464cbb78dccd784c9b70a5592a97c067",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.229047,
+            "end": 1771974863.229047,
+            "events": {
+              "name": "pk::derive",
+              "pk::algorithm": "ECDH (X25519)"
             }
           }
         ]
@@ -173,39 +290,16 @@
         ]
       },
       {
-        "context": "9c3eb879769d1ca094404184669f6d60",
+        "context": "f574d1bf35c80d999cd45243992cbcf3",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
-        "start": 1771974863.2288046,
-        "end": 1771974863.2288046,
+        "start": 1771974863.2471,
+        "end": 1771974863.2471,
         "events": {
-          "name": "tls::key_exchange",
-          "tls::group": 4588
-        },
-        "spans": [
-          {
-            "context": "464cbb78dccd784c9b70a5592a97c067",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974863.229047,
-            "end": 1771974863.229047,
-            "events": {
-              "name": "pk::derive",
-              "pk::algorithm": "ECDH (X25519)"
-            }
-          },
-          {
-            "context": "6b12b88a73508c86569afb171fc86fa2",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974863.2288072,
-            "end": 1771974863.2288072,
-            "events": {
-              "name": "pk::decapsulate",
-              "pk::algorithm": "ML-KEM-768"
-            }
-          }
-        ]
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 4096
+        }
       },
       {
         "context": "f574d1bf35c80d999cd45243992cbcf3",
@@ -232,6 +326,66 @@
       "tls::protocol_version": 772
     },
     "spans": [
+      {
+        "context": "174de05063ba9b25008b373abab6edc2",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974923.450032,
+        "end": 1771974923.450032,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "d80cae8a628eaa81be9838bac8f60ab4",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974923.4500358,
+            "end": 1771974923.4500358,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "14efe57e720da4a10a394fd70bfd75cd",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974923.4501417,
+            "end": 1771974923.4501417,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ECDH (X25519)"
+            }
+          }
+        ]
+      },
+      {
+        "context": "174de05063ba9b25008b373abab6edc2",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974923.4501987,
+        "end": 1771974923.4501987,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 23
+        },
+        "spans": [
+          {
+            "context": "ac972e44ea6bcef3b4a63cbe53a80cc9",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974923.4502006,
+            "end": 1771974923.4502006,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "EC/ECDSA",
+              "pk::curve": "SECP256R1"
+            }
+          }
+        ]
+      },
       {
         "context": "086f6407cbc7d1ab26012b7e939373c4",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
@@ -268,43 +422,6 @@
         ]
       },
       {
-        "context": "174de05063ba9b25008b373abab6edc2",
-        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-        "executable": "",
-        "start": 1771974923.4501987,
-        "end": 1771974923.4501987,
-        "events": {
-          "name": "tls::key_exchange",
-          "tls::group": 23
-        },
-        "spans": [
-          {
-            "context": "ac972e44ea6bcef3b4a63cbe53a80cc9",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974923.4502006,
-            "end": 1771974923.4502006,
-            "events": {
-              "name": "pk::generate",
-              "pk::algorithm": "EC/ECDSA",
-              "pk::curve": "SECP256R1"
-            }
-          }
-        ]
-      },
-      {
-        "context": "520f84448e7d46817efd218659951f35",
-        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-        "executable": "",
-        "start": 1771974923.4855325,
-        "end": 1771974923.4855325,
-        "events": {
-          "name": "pk::verify",
-          "pk::algorithm": "RSA",
-          "pk::bits": 2048
-        }
-      },
-      {
         "context": "7efbca0e91133d460bbabf918ea3d2d5",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
@@ -329,6 +446,30 @@
             }
           }
         ]
+      },
+      {
+        "context": "520f84448e7d46817efd218659951f35",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974923.4853485,
+        "end": 1771974923.4853485,
+        "events": {
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 4096
+        }
+      },
+      {
+        "context": "520f84448e7d46817efd218659951f35",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974923.4855325,
+        "end": 1771974923.4855325,
+        "events": {
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 2048
+        }
       }
     ]
   }

--- a/fixtures/logs/since-until/since-until.json
+++ b/fixtures/logs/since-until/since-until.json
@@ -14,6 +14,41 @@
         "context": "4496299804038c7e426b63ba21e82767",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
+        "start": 1771974863.2147295,
+        "end": 1771974863.2147295,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "1f7c9636c1a8b39cc33164443e937a9a",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2147315,
+            "end": 1771974863.2147315,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "ba9a72d4606fc745e6a46281e9e0d88c",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2148237,
+            "end": 1771974863.2148237,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ECDH (X25519)"
+            }
+          }
+        ]
+      },
+      {
+        "context": "4496299804038c7e426b63ba21e82767",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
         "start": 1771974863.2148774,
         "end": 1771974863.2148774,
         "events": {
@@ -31,6 +66,41 @@
               "name": "pk::generate",
               "pk::algorithm": "EC/ECDSA",
               "pk::curve": "SECP256R1"
+            }
+          }
+        ]
+      },
+      {
+        "context": "9c3eb879769d1ca094404184669f6d60",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974863.2288046,
+        "end": 1771974863.2288046,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "6b12b88a73508c86569afb171fc86fa2",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2288072,
+            "end": 1771974863.2288072,
+            "events": {
+              "name": "pk::decapsulate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "464cbb78dccd784c9b70a5592a97c067",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.229047,
+            "end": 1771974863.229047,
+            "events": {
+              "name": "pk::derive",
+              "pk::algorithm": "ECDH (X25519)"
             }
           }
         ]
@@ -62,39 +132,16 @@
         ]
       },
       {
-        "context": "9c3eb879769d1ca094404184669f6d60",
+        "context": "f574d1bf35c80d999cd45243992cbcf3",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
-        "start": 1771974863.2288046,
-        "end": 1771974863.2288046,
+        "start": 1771974863.2471,
+        "end": 1771974863.2471,
         "events": {
-          "name": "tls::key_exchange",
-          "tls::group": 4588
-        },
-        "spans": [
-          {
-            "context": "464cbb78dccd784c9b70a5592a97c067",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974863.229047,
-            "end": 1771974863.229047,
-            "events": {
-              "name": "pk::derive",
-              "pk::algorithm": "ECDH (X25519)"
-            }
-          },
-          {
-            "context": "6b12b88a73508c86569afb171fc86fa2",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974863.2288072,
-            "end": 1771974863.2288072,
-            "events": {
-              "name": "pk::decapsulate",
-              "pk::algorithm": "ML-KEM-768"
-            }
-          }
-        ]
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 4096
+        }
       },
       {
         "context": "f574d1bf35c80d999cd45243992cbcf3",

--- a/fixtures/logs/since-until/since.json
+++ b/fixtures/logs/since-until/since.json
@@ -14,6 +14,41 @@
         "context": "4496299804038c7e426b63ba21e82767",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
+        "start": 1771974863.2147295,
+        "end": 1771974863.2147295,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "1f7c9636c1a8b39cc33164443e937a9a",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2147315,
+            "end": 1771974863.2147315,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "ba9a72d4606fc745e6a46281e9e0d88c",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2148237,
+            "end": 1771974863.2148237,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ECDH (X25519)"
+            }
+          }
+        ]
+      },
+      {
+        "context": "4496299804038c7e426b63ba21e82767",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
         "start": 1771974863.2148774,
         "end": 1771974863.2148774,
         "events": {
@@ -31,6 +66,41 @@
               "name": "pk::generate",
               "pk::algorithm": "EC/ECDSA",
               "pk::curve": "SECP256R1"
+            }
+          }
+        ]
+      },
+      {
+        "context": "9c3eb879769d1ca094404184669f6d60",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974863.2288046,
+        "end": 1771974863.2288046,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "6b12b88a73508c86569afb171fc86fa2",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2288072,
+            "end": 1771974863.2288072,
+            "events": {
+              "name": "pk::decapsulate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "464cbb78dccd784c9b70a5592a97c067",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.229047,
+            "end": 1771974863.229047,
+            "events": {
+              "name": "pk::derive",
+              "pk::algorithm": "ECDH (X25519)"
             }
           }
         ]
@@ -62,39 +132,16 @@
         ]
       },
       {
-        "context": "9c3eb879769d1ca094404184669f6d60",
+        "context": "f574d1bf35c80d999cd45243992cbcf3",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
-        "start": 1771974863.2288046,
-        "end": 1771974863.2288046,
+        "start": 1771974863.2471,
+        "end": 1771974863.2471,
         "events": {
-          "name": "tls::key_exchange",
-          "tls::group": 4588
-        },
-        "spans": [
-          {
-            "context": "464cbb78dccd784c9b70a5592a97c067",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974863.229047,
-            "end": 1771974863.229047,
-            "events": {
-              "name": "pk::derive",
-              "pk::algorithm": "ECDH (X25519)"
-            }
-          },
-          {
-            "context": "6b12b88a73508c86569afb171fc86fa2",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974863.2288072,
-            "end": 1771974863.2288072,
-            "events": {
-              "name": "pk::decapsulate",
-              "pk::algorithm": "ML-KEM-768"
-            }
-          }
-        ]
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 4096
+        }
       },
       {
         "context": "f574d1bf35c80d999cd45243992cbcf3",
@@ -121,6 +168,66 @@
       "tls::protocol_version": 772
     },
     "spans": [
+      {
+        "context": "174de05063ba9b25008b373abab6edc2",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974923.450032,
+        "end": 1771974923.450032,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "d80cae8a628eaa81be9838bac8f60ab4",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974923.4500358,
+            "end": 1771974923.4500358,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "14efe57e720da4a10a394fd70bfd75cd",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974923.4501417,
+            "end": 1771974923.4501417,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ECDH (X25519)"
+            }
+          }
+        ]
+      },
+      {
+        "context": "174de05063ba9b25008b373abab6edc2",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974923.4501987,
+        "end": 1771974923.4501987,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 23
+        },
+        "spans": [
+          {
+            "context": "ac972e44ea6bcef3b4a63cbe53a80cc9",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974923.4502006,
+            "end": 1771974923.4502006,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "EC/ECDSA",
+              "pk::curve": "SECP256R1"
+            }
+          }
+        ]
+      },
       {
         "context": "086f6407cbc7d1ab26012b7e939373c4",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
@@ -157,43 +264,6 @@
         ]
       },
       {
-        "context": "174de05063ba9b25008b373abab6edc2",
-        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-        "executable": "",
-        "start": 1771974923.4501987,
-        "end": 1771974923.4501987,
-        "events": {
-          "name": "tls::key_exchange",
-          "tls::group": 23
-        },
-        "spans": [
-          {
-            "context": "ac972e44ea6bcef3b4a63cbe53a80cc9",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974923.4502006,
-            "end": 1771974923.4502006,
-            "events": {
-              "name": "pk::generate",
-              "pk::algorithm": "EC/ECDSA",
-              "pk::curve": "SECP256R1"
-            }
-          }
-        ]
-      },
-      {
-        "context": "520f84448e7d46817efd218659951f35",
-        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-        "executable": "",
-        "start": 1771974923.4855325,
-        "end": 1771974923.4855325,
-        "events": {
-          "name": "pk::verify",
-          "pk::algorithm": "RSA",
-          "pk::bits": 2048
-        }
-      },
-      {
         "context": "7efbca0e91133d460bbabf918ea3d2d5",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
@@ -218,6 +288,30 @@
             }
           }
         ]
+      },
+      {
+        "context": "520f84448e7d46817efd218659951f35",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974923.4853485,
+        "end": 1771974923.4853485,
+        "events": {
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 4096
+        }
+      },
+      {
+        "context": "520f84448e7d46817efd218659951f35",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974923.4855325,
+        "end": 1771974923.4855325,
+        "events": {
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 2048
+        }
       }
     ]
   }

--- a/fixtures/logs/since-until/until.json
+++ b/fixtures/logs/since-until/until.json
@@ -14,6 +14,41 @@
         "context": "3cb4522554c9b0dc609cb15a60e8066d",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
+        "start": 1771974803.010911,
+        "end": 1771974803.010911,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "f34bb5200436326560d85aa040c2edc4",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974803.010913,
+            "end": 1771974803.010913,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "4886da6e495c21dd4269881115794cc2",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974803.0110207,
+            "end": 1771974803.0110207,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ECDH (X25519)"
+            }
+          }
+        ]
+      },
+      {
+        "context": "3cb4522554c9b0dc609cb15a60e8066d",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
         "start": 1771974803.0110753,
         "end": 1771974803.0110753,
         "events": {
@@ -71,18 +106,6 @@
         ]
       },
       {
-        "context": "ba2f7865e4de038b3da670176ac134aa",
-        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-        "executable": "",
-        "start": 1771974803.0425448,
-        "end": 1771974803.0425448,
-        "events": {
-          "name": "pk::verify",
-          "pk::algorithm": "RSA",
-          "pk::bits": 2048
-        }
-      },
-      {
         "context": "dcb5668c7981c908da00c4f485aa28fe",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
@@ -107,6 +130,30 @@
             }
           }
         ]
+      },
+      {
+        "context": "ba2f7865e4de038b3da670176ac134aa",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974803.0423572,
+        "end": 1771974803.0423572,
+        "events": {
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 4096
+        }
+      },
+      {
+        "context": "ba2f7865e4de038b3da670176ac134aa",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974803.0425448,
+        "end": 1771974803.0425448,
+        "events": {
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 2048
+        }
       }
     ]
   },
@@ -121,6 +168,41 @@
       "tls::protocol_version": 772
     },
     "spans": [
+      {
+        "context": "4496299804038c7e426b63ba21e82767",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974863.2147295,
+        "end": 1771974863.2147295,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "1f7c9636c1a8b39cc33164443e937a9a",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2147315,
+            "end": 1771974863.2147315,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "ba9a72d4606fc745e6a46281e9e0d88c",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2148237,
+            "end": 1771974863.2148237,
+            "events": {
+              "name": "pk::generate",
+              "pk::algorithm": "ECDH (X25519)"
+            }
+          }
+        ]
+      },
       {
         "context": "4496299804038c7e426b63ba21e82767",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
@@ -142,6 +224,41 @@
               "name": "pk::generate",
               "pk::algorithm": "EC/ECDSA",
               "pk::curve": "SECP256R1"
+            }
+          }
+        ]
+      },
+      {
+        "context": "9c3eb879769d1ca094404184669f6d60",
+        "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+        "executable": "",
+        "start": 1771974863.2288046,
+        "end": 1771974863.2288046,
+        "events": {
+          "name": "tls::key_exchange",
+          "tls::group": 4588
+        },
+        "spans": [
+          {
+            "context": "6b12b88a73508c86569afb171fc86fa2",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.2288072,
+            "end": 1771974863.2288072,
+            "events": {
+              "name": "pk::decapsulate",
+              "pk::algorithm": "ML-KEM-768"
+            }
+          },
+          {
+            "context": "464cbb78dccd784c9b70a5592a97c067",
+            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
+            "executable": "",
+            "start": 1771974863.229047,
+            "end": 1771974863.229047,
+            "events": {
+              "name": "pk::derive",
+              "pk::algorithm": "ECDH (X25519)"
             }
           }
         ]
@@ -173,39 +290,16 @@
         ]
       },
       {
-        "context": "9c3eb879769d1ca094404184669f6d60",
+        "context": "f574d1bf35c80d999cd45243992cbcf3",
         "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
         "executable": "",
-        "start": 1771974863.2288046,
-        "end": 1771974863.2288046,
+        "start": 1771974863.2471,
+        "end": 1771974863.2471,
         "events": {
-          "name": "tls::key_exchange",
-          "tls::group": 4588
-        },
-        "spans": [
-          {
-            "context": "464cbb78dccd784c9b70a5592a97c067",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974863.229047,
-            "end": 1771974863.229047,
-            "events": {
-              "name": "pk::derive",
-              "pk::algorithm": "ECDH (X25519)"
-            }
-          },
-          {
-            "context": "6b12b88a73508c86569afb171fc86fa2",
-            "origin": "25afdfb85a5c7626b28a77ac4dce92637f7c842a",
-            "executable": "",
-            "start": 1771974863.2288072,
-            "end": 1771974863.2288072,
-            "events": {
-              "name": "pk::decapsulate",
-              "pk::algorithm": "ML-KEM-768"
-            }
-          }
-        ]
+          "name": "pk::verify",
+          "pk::algorithm": "RSA",
+          "pk::bits": 4096
+        }
       },
       {
         "context": "f574d1bf35c80d999cd45243992cbcf3",


### PR DESCRIPTION
Using a BTreeMap to track previous context prevents multiple sibling
contexts from sharing the same context ID.  This patch switches it to
using a Vec to keep both siblings when updating.  This may have a
performance implication, though it should be limited given log entries
are periodically flushed.