### PR TITLE
docs: Add new syntax to the event schema

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -54,11 +54,16 @@ All data events defined in this document are optional.
 
 #### Context events
 
-A context event is defined using a `context <name> { ... }` block,
-where `<name>` is the name of the context event. The body of this block
-may contain data events or other context events.
+A context event is defined with a `context <name>[, <name>...] { ... }`
+directive.
 
-For example, 
+`<name>` is the name of the context event. Multiple context events can
+be defined at once, whose names are separated by `,`.
+
+The body of this block may contain data events or other context
+events.
+
+For example,
 
 ```
 context c1 {
@@ -98,7 +103,7 @@ defined as follows:
 
 ```
 scope pk {
-  context sign {
+  context sign, verify {
     algorithm: string;
     curve: string;
     bits: uint16;
@@ -106,33 +111,14 @@ scope pk {
     rsa_padding: string;
   }
 
-  context verify {
-    algorithm: string;
-    curve: string;
-    bits: uint16;
-    hash: string;
-    rsa_padding: string;
-  }
-
-  context encrypt {
+  context encrypt, decrypt {
     algorithm: string;
     bits: uint16;
     hash: string;
     rsa_padding: string;
   }
 
-  context decrypt {
-    algorithm: string;
-    bits: uint16;
-    hash: string;
-    rsa_padding: string;
-  }
-
-  context encapsulate {
-    algorithm: string;
-  }
-
-  context decapsulate {
+  context encapsulate, decapsulate {
     algorithm: string;
   }
 
@@ -194,11 +180,7 @@ scope tls {
       group: uint16;
     }
 
-    context sign {
-      signature_algorithm: uint16;
-    }
-
-    context verify {
+    context sign, verify {
       signature_algorithm: uint16;
     }
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -65,9 +65,9 @@ context c1 {
   s1: string;
   context c2 {
     u1: uint16;
-	context c3 {
-	  i1: int16;
-	}
+    context c3 {
+      i1: int16;
+    }
   }
 }
 ```
@@ -100,32 +100,32 @@ defined as follows:
 scope pk {
   context sign {
     algorithm: string;
-	curve: string;
-	bits: uint16;
-	hash: string;
-	rsa_padding: string;
+    curve: string;
+    bits: uint16;
+    hash: string;
+    rsa_padding: string;
   }
 
   context verify {
     algorithm: string;
-	curve: string;
-	bits: uint16;
-	hash: string;
-	rsa_padding: string;
+    curve: string;
+    bits: uint16;
+    hash: string;
+    rsa_padding: string;
   }
 
   context encrypt {
     algorithm: string;
-	bits: uint16;
-	hash: string;
-	rsa_padding: string;
+    bits: uint16;
+    hash: string;
+    rsa_padding: string;
   }
 
   context decrypt {
     algorithm: string;
-	bits: uint16;
-	hash: string;
-	rsa_padding: string;
+    bits: uint16;
+    hash: string;
+    rsa_padding: string;
   }
 
   context encapsulate {
@@ -138,17 +138,17 @@ scope pk {
 
   context generate {
     algorithm: string;
-	curve: string;
-	group: string;
-	bits: uint16;
+    curve: string;
+    group: string;
+    bits: uint16;
   }
 
   context derive {
     algorithm: string;
-	curve: string;
-	group: string;
-	bits: uint16;
-	static: bool;
+    curve: string;
+    group: string;
+    bits: uint16;
+    static: bool;
   }
 }
 ```
@@ -187,24 +187,24 @@ defined as follows:
 scope tls {
   context handshake {
     role: string;
-	protocol_version: uint16;
-	ciphersuite: uint16;
+    protocol_version: uint16;
+    ciphersuite: uint16;
 
-	context key_exchange {
-	  group: uint16;
-	}
+    context key_exchange {
+      group: uint16;
+    }
 
-	context sign {
-	  signature_algorithm: uint16;
-	}
+    context sign {
+      signature_algorithm: uint16;
+    }
 
-	context verify {
-	  signature_algorithm: uint16;
-	}
+    context verify {
+      signature_algorithm: uint16;
+    }
 
-	context verify_cert_chain {}
+    context verify_cert_chain {}
 
-	extended_master_secret: bool;
+    extended_master_secret: bool;
   }
 }
 ```
@@ -239,31 +239,31 @@ follows:
 scope ssh {
   context handshake {
     role: string;
-	ident_string: string;
-	peer_ident_string: string;
-	context key_exchange {
-	  kex_algorithm: string;
-	  kex_group: string;
-	  key_algorithm: string;
-	  c2s_cipher: string;
-	  s2c_cipher: string;
-	  c2s_mac: string;
-	  s2c_mac: string;
-	  c2s_compression: string;
-	  s2c_compression: string;
-	}
+    ident_string: string;
+    peer_ident_string: string;
+    context key_exchange {
+      kex_algorithm: string;
+      kex_group: string;
+      key_algorithm: string;
+      c2s_cipher: string;
+      s2c_cipher: string;
+      c2s_mac: string;
+      s2c_mac: string;
+      c2s_compression: string;
+      s2c_compression: string;
+    }
 
-	context client_key {
-	  key_algorithm: string;
-	  cert_signature_algorithm: string;
-	  rsa_bits: uint16;
-	}
+    context client_key {
+      key_algorithm: string;
+      cert_signature_algorithm: string;
+      rsa_bits: uint16;
+    }
 
-	context server_key {
-	  key_algorithm: string;
-	  cert_signature_algorithm: string;
-	  rsa_bits: uint16;
-	}
+    context server_key {
+      key_algorithm: string;
+      cert_signature_algorithm: string;
+      rsa_bits: uint16;
+    }
   }
 }
 ```

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -81,11 +81,28 @@ The hierarchy of context events must be preserved within the same scope.
 In the example above, `c2` cannot appear at the top level, and `c3`
 cannot be placed directly under `c1`.
 
-However, context events defined at top-level can be nested.  For
-example, `pk::derive` may appear within `tls::key_exchange`, as well
-as `pk::decapsulate` may be placed under another `pk::decapsulate` if
-the algorithm is defined using a hybrid construction, such as
-X25519MLKEM768.
+##### Referencing context events
+
+The `ref <pattern>[, <pattern>]` directive can be used to reference
+context events by a glob pattern given by `<pattern>`. Multiple
+patterns can be specified at once, delimited by a `,`.
+
+For example,
+
+```
+scope this {
+  context c1 {
+    s1: string;
+    context c2 {
+      u1: uint16;
+      ref other::*;
+    }
+  }
+}
+```
+
+This means that any context events defined in the `other` scope may
+appear under `this::c2` context.
 
 ## Generic data events
 
@@ -118,8 +135,14 @@ scope pk {
     rsa_padding: string;
   }
 
-  context encapsulate, decapsulate {
+  context encapsulate {
     algorithm: string;
+    ref pk::derive, pk::encapsulate; /* for hybrids */
+  }
+
+  context decapsulate {
+    algorithm: string;
+    ref pk::derive, pk::decapsulate; /* for hybrids */
   }
 
   context generate {
@@ -178,13 +201,17 @@ scope tls {
 
     context key_exchange {
       group: uint16;
+      ref pk::generate, pk::derive, pk::encapsulate, pk::decapsulate;
     }
 
     context sign, verify {
       signature_algorithm: uint16;
+      ref pk::sign, pk::verify;
     }
 
-    context verify_cert_chain {}
+    context verify_cert_chain {
+      ref pk::verify;
+    }
 
     extended_master_secret: bool;
   }

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -232,6 +232,8 @@ scope tls {
 
 ## SSH
 
+Note: This section is not finalized yet.
+
 Events for SSH (Secure SHell) are scoped with `ssh` and defined as
 follows:
 


### PR DESCRIPTION
This allows multiple context events to be specified at once to avoid repetition. It also makes scope interleave stricter with the new `ref` keyword.