### PR TITLE
schema: Fix allowed_children extraction for root contexts

### DIFF
--- a/crypto-auditing/src/builtin.schema
+++ b/crypto-auditing/src/builtin.schema
@@ -58,10 +58,16 @@ scope tls {
       allowed_children pk::generate, pk::derive, pk::encapsulate, pk::decapsulate;
     }
 
-    /* A TLS handshake message (e.g., CertificateVerify in TLS 1.3) is digitally signed or verified */
-    context sign, verify {
+    /* A TLS handshake message (e.g., CertificateVerify in TLS 1.3) is digitally signed */
+    context sign {
       signature_algorithm: uint16;
-      allowed_children pk::sign, pk::verify;
+      allowed_children pk::sign;
+    }
+
+    /* A TLS handshake message (e.g., CertificateVerify in TLS 1.3) is verified */
+    context verify {
+      signature_algorithm: uint16;
+      allowed_children pk::verify;
     }
 
     /* A certificate chain presented during a TLS handshake is verified */

--- a/crypto-auditing/src/schema.rs
+++ b/crypto-auditing/src/schema.rs
@@ -304,14 +304,10 @@ impl Schema {
             }
         }
         for child in children {
-            if let Some(v) = parents.get_mut(&child) {
-                v.push(child);
-            } else {
-                parents.insert(
-                    child,
-                    vec![Name::new(scope.name.as_str(), parent.name.as_str())],
-                );
-            }
+            parents
+                .entry(child)
+                .or_default()
+                .push(Name::new(scope.name.as_str(), parent.name.as_str()));
         }
     }
 
@@ -362,5 +358,6 @@ mod tests {
             &Name::new("pk", "encapsulate")
         ));
         assert!(!builtin.is_parent(&Name::new("tls", "sign"), &Name::new("pk", "encapsulate")));
+        assert!(!builtin.is_parent(&Name::new("pk", "verify"), &Name::new("pk", "verify")));
     }
 }

--- a/crypto-auditing/src/schema.rs
+++ b/crypto-auditing/src/schema.rs
@@ -3,7 +3,7 @@
 
 use pest::Parser;
 use pest::iterators::Pair;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 
 #[derive(Parser)]
@@ -115,7 +115,7 @@ pub struct Scope {
 #[derive(Debug, Default)]
 pub struct Schema {
     pub scopes: Vec<Scope>,
-    parents: HashMap<Name, Vec<Name>>,
+    parents: HashMap<Name, HashSet<Name>>,
 }
 
 fn parse_allowed_children(name: &str, pair: Pair<Rule>) -> Vec<Pattern> {
@@ -252,12 +252,12 @@ impl Schema {
     pub fn is_parent(&self, parent_name: &Name, name: &Name) -> bool {
         self.parents
             .get(name)
-            .map(|parents| parents.iter().any(|x| x == parent_name))
+            .map(|parents| parents.contains(parent_name))
             .unwrap_or(false)
     }
 
     fn extract_direct_parents(
-        parents: &mut HashMap<Name, Vec<Name>>,
+        parents: &mut HashMap<Name, HashSet<Name>>,
         scope: &Scope,
         parent: &ContextEvent,
     ) {
@@ -269,12 +269,15 @@ impl Schema {
             }
         }
         for child in children {
-            parents.insert(child, vec![Name::new(&scope.name, &parent.name)]);
+            parents
+                .entry(child)
+                .or_default()
+                .insert(Name::new(&scope.name, &parent.name));
         }
     }
 
     fn extract_allowed_children(
-        parents: &mut HashMap<Name, Vec<Name>>,
+        parents: &mut HashMap<Name, HashSet<Name>>,
         scope: &Scope,
         parent: &ContextEvent,
         roots: &HashMap<String, Vec<Name>>,
@@ -307,7 +310,7 @@ impl Schema {
             parents
                 .entry(child)
                 .or_default()
-                .push(Name::new(scope.name.as_str(), parent.name.as_str()));
+                .insert(Name::new(scope.name.as_str(), parent.name.as_str()));
         }
     }
 


### PR DESCRIPTION
There was a logic error when parsing `allowed_children`, when another context is already registered under a same parent. In that case, it inserted itself as its parent. This fixes it as well as switches to using `HashSet` to maintain parents.